### PR TITLE
Update to JMeter 5.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,17 @@ reduce the processing time in comparison with JTL/CSV file upload.
 
 ![JtlReporter JMeter Backend Listener](./assets/listener_screenshot.png)
 
+## Build plugin from source
+```./gradle clean jar```
+
+Copy generated jar file from [build/libs/](build/libs) into `$JMETER_HOME/lib/ext/`
+
+
 ## Setup
 All the below-mentioned properties are required.
-* `jtlreporter.project.name` existing project name.
+* `jtlreporter.project.name`, existing project name.
 * `jtlreporter.scenario.name`, existing scenario name.
-* `jtlreporter.environment` test environment.
+* `jtlreporter.environment`, test environment.
 * `jtlreporter.backend.url`, JtlReporter Backend url.
 * `jtlreporter.listener.service.url`, JtlReporter Listener Service url.
 * `jtlreporter.api.token`, [API token](https://jtlreporter.site/docs/guides/administration/api-token).

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ reduce the processing time in comparison with JTL/CSV file upload.
 All the below-mentioned properties are required.
 * `jtlreporter.project.name` existing project name.
 * `jtlreporter.scenario.name`, existing scenario name.
-* `jtlreporter.environment` test environment. 
+* `jtlreporter.environment` test environment.
 * `jtlreporter.backend.url`, JtlReporter Backend url.
 * `jtlreporter.listener.service.url`, JtlReporter Listener Service url.
 * `jtlreporter.api.token`, [API token](https://jtlreporter.site/docs/guides/administration/api-token).
-* `jtlreporter.batch.size`, max value is 500. 
+* `jtlreporter.batch.size`, max value is 500.

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 
-sourceCompatibility = 17
+sourceCompatibility = 11
 group = 'jtlreporter'
 version = '0.4'
 
@@ -86,12 +86,6 @@ shadowJar {
 
     // Removes the 'All' in Classifier to have downloadable artifact by default.
     archiveClassifier.set(null)
-
-    duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,9 @@ repositories {
 }
 
 
-sourceCompatibility = 11
+sourceCompatibility = 17
 group = 'jtlreporter'
-version = '0.3'
+version = '0.4'
 
 def title = 'JtlReporterBackendListener'
 def archiveName = 'jmeter-plugins-jtlreporter-listener'
@@ -36,10 +36,12 @@ class JMeterRule implements ComponentMetadataRule {
     }
 }
 
+String jMeterVersion = '5.6.2'
+
 dependencies {
-    implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_core', version: '5.5'
-    implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_java', version: '5.5'
-    implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_components', version: '5.5'
+    compileOnly group: 'org.apache.jmeter', name: 'ApacheJMeter_core', version: jMeterVersion
+    compileOnly group: 'org.apache.jmeter', name: 'ApacheJMeter_java', version: jMeterVersion
+    compileOnly group: 'org.apache.jmeter', name: 'ApacheJMeter_components', version: jMeterVersion
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.11.0'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     components {
@@ -61,6 +63,11 @@ jar {
 
     // Sets Classifier as sources.
     archiveClassifier.set("sources")
+    duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+
 }
 
 shadowJar {
@@ -79,6 +86,11 @@ shadowJar {
 
     // Removes the 'All' in Classifier to have downloadable artifact by default.
     archiveClassifier.set(null)
+
+    duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
 
 }
 

--- a/src/main/java/jtlreporter/JtlReporterBackendClient.java
+++ b/src/main/java/jtlreporter/JtlReporterBackendClient.java
@@ -4,20 +4,24 @@ import com.google.gson.Gson;
 import jtlreporter.model.Constants;
 import jtlreporter.model.JwtResponse;
 import jtlreporter.model.StartAsyncResponse;
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.visualizers.backend.AbstractBackendListenerClient;
 import org.apache.jmeter.visualizers.backend.BackendListenerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import okhttp3.*;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public class JtlReporterBackendClient extends AbstractBackendListenerClient {
+public class JtlReporterBackendClient extends AbstractBackendListenerClient implements Runnable {
 
     private static final String JTL_BACKEND_URL = "jtlreporter.backend.url";
     private static final String JTL_LISTENER_SERVICE_URL = "jtlreporter.listener.service.url";
@@ -94,9 +98,7 @@ public class JtlReporterBackendClient extends AbstractBackendListenerClient {
             try {
                 this.sender.addToList(metric.getMetric());
             } catch (Exception e) {
-                logger.error(
-                        "JtlReporter Listener was unable to add sampler to the list of samplers to be sent... More info in JMeter's console.");
-                e.printStackTrace();
+                logger.error("JtlReporter Listener was unable to add sampler '" + sr.getSampleLabel() + "' to the list of samplers to be sent... More info in JMeter's console.", e);
             }
         }
         if (this.sender.getListSize() >= this.bulkSize) {
@@ -216,8 +218,13 @@ public class JtlReporterBackendClient extends AbstractBackendListenerClient {
             Boolean result = this.sender.logSamples();
             if (!result) {
                 --retryCount;
-                logger.info("Upload failed " + retryCount + " attempts left." );
+                logger.info("Upload failed " + retryCount + " attempts left.");
             }
         }
+    }
+
+    @Override
+    public void run() {
+        /* nothing to do, since everything is handled in handleSampleResults() */
     }
 }

--- a/src/main/java/jtlreporter/JtlReporterMetric.java
+++ b/src/main/java/jtlreporter/JtlReporterMetric.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 
 public class JtlReporterMetric {
     private static final Logger logger = LoggerFactory.getLogger(JtlReporterMetric.class);
-    private SampleResult sampleResult;
+    private final SampleResult sampleResult;
 
     public JtlReporterMetric(SampleResult sr) {
         this.sampleResult = sr;
@@ -18,7 +18,7 @@ public class JtlReporterMetric {
      *
      * @return a Sample
      */
-    public Sample getMetric() throws Exception {
+    public Sample getMetric() {
 
         return new Sample(
                 this.sampleResult.getTimeStamp(),

--- a/src/main/java/jtlreporter/model/Sample.java
+++ b/src/main/java/jtlreporter/model/Sample.java
@@ -3,27 +3,27 @@ package jtlreporter.model;
 import java.net.URL;
 
 public class Sample {
-    private Long timeStamp;
-    private Long elapsed;
-    private Long bytes;
-    private String label;
-    private String responseCode;
-    private String responseMessage;
-    private Boolean success;
-    private Integer grpThreads;
-    private Integer allThreads;
-    private Long latency;
-    private Long connect;
-    private String hostname;
-    private String threadName;
-    private String failureMessage;
-    private Long sentBytes;
+    private final Long timeStamp;
+    private final Long elapsed;
+    private final Long bytes;
+    private final String label;
+    private final String responseCode;
+    private final String responseMessage;
+    private final Boolean success;
+    private final Integer grpThreads;
+    private final Integer allThreads;
+    private final Long latency;
+    private final Long connect;
+    private final String hostname;
+    private final String threadName;
+    private final String failureMessage;
+    private final Long sentBytes;
 
 
     public Sample(
             Long timeStamp,
-            Long  elapsed,
-            Long  bytes,
+            Long elapsed,
+            Long bytes,
             String label,
             String responseCode,
             String responseMessage,
@@ -48,7 +48,7 @@ public class Sample {
         this.allThreads = allThreads;
         this.latency = latency;
         this.connect = connect;
-        this.hostname = hostname.toString();
+        this.hostname = hostname != null ? hostname.toString() : null;
         this.threadName = threadName;
         this.sentBytes = sentBytes;
         this.failureMessage = failureMessage;


### PR DESCRIPTION
Update the BackendListener to be usable with JMeter 5.6.2.

Also I enhanced the error output to detect, that some Samples have no hostname (in my case,  Transaction Sampler). To use this Plugin, the hostname can be null.